### PR TITLE
Fix CI: smoke test import path + add ESLint v9 config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,21 @@
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    files: ['src/**/*.ts'],
+    extends: tseslint.configs.recommended,
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.json',
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/no-explicit-any': 'warn',
+    },
+  },
+  {
+    ignores: ['dist/', 'node_modules/', 'coverage/'],
+  }
+);

--- a/test/smoke/smoke.test.ts
+++ b/test/smoke/smoke.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest';
 
 describe('smoke tests', () => {
-  it('module loads without errors', () => {
-    // The module should be importable without throwing
-    expect(() => import('../src/index.js')).not.toThrow();
+  it('module loads without errors', async () => {
+    // The compiled module should be importable without throwing
+    await expect(import('../../dist/index.js')).resolves.toBeDefined();
   });
 
   it('core module exports are defined', async () => {
-    const mod = await import('../src/index.js');
+    const mod = await import('../../dist/index.js');
     // At minimum, the module should load — add assertions as exports grow
     expect(mod).toBeDefined();
   });


### PR DESCRIPTION
Fixes the broken CI chain (build → test → lint):

**Smoke test fix:** Imports from `../../dist/index.js` instead of `../src/index.js` (which doesn't exist as a source file). CI runs `build` first, so dist/ is populated before test runs.

**ESLint config:** Adds `eslint.config.js` (ESLint v9 flat config with typescript-eslint). Lint step was failing because no config existed.

**Note:** The tsconfig.json (module: NodeNext, moduleResolution: NodeNext) is already correct in main and is unchanged here.