### PR TITLE
Add success-stamp reader fixture for guard liveness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "prettier": "^3.0.0",
         "tsx": "^4.0.0",
         "typescript": "^5.6.0",
+        "typescript-eslint": "^8.65.0",
         "vitest": "^2.0.0"
       },
       "engines": {
@@ -1039,6 +1040,288 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -1641,6 +1924,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2074,6 +2375,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -2204,6 +2518,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2298,6 +2625,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/tinypool": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
@@ -2326,6 +2670,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/tsx": {
@@ -2373,6 +2730,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prettier": "^3.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.6.0",
+    "typescript-eslint": "^8.65.0",
     "vitest": "^2.0.0"
   },
   "engines": {

--- a/src/guard/stamp-reader.ts
+++ b/src/guard/stamp-reader.ts
@@ -1,0 +1,159 @@
+/**
+ * Success-stamp reader: the follow-up layer to the liveness-of-guard fixture.
+ *
+ * PR #14 proved that a guard which actually runs can distinguish CLEAN, RED,
+ * and BLIND, and that a clean run stays silent while writing a success stamp.
+ * This file reads that stamp from outside the guard. It closes the residual:
+ * silence from a disabled, masked, uninstalled, or never-scheduled guard is
+ * byte-identical to silence from a healthy guard unless something else reads a
+ * recent control stamp.
+ *
+ * This is monitoring/liveness evidence only. It does not settle the subject of
+ * the audit. A stale or missing control is BLIND/UNKNOWN — a claim about our
+ * instrument — not RED, which would be a claim about the subject.
+ */
+
+/** A subject input that made the guard reject. Presence means the guard found RED. */
+export interface GuardFireRecord {
+  at: string;
+  input: string;
+}
+
+/**
+ * Readable JSON-ish stamp schema for guard liveness.
+ *
+ * `guard_control_at` is the liveness proof: a known-bad control was recently
+ * fed into the guard and rejected. `control_corpus_hash` prevents a shrinking
+ * control corpus from looking fresh forever. `control_max_age_ms` is the
+ * explicit freshness rule. `guard_skipped` makes enumerator blind spots visible
+ * instead of letting a partial scan present as full coverage.
+ */
+export interface GuardStamp {
+  unit: string;
+  stamped_at: string;
+  guard_control_at?: string | null;
+  control_corpus_hash?: string | null;
+  control_max_age_ms: number;
+  guard_skipped?: string[];
+  guard_fired_at?: GuardFireRecord | null;
+}
+
+export type StampReaderOutcome = "OK" | "RED" | "BLIND";
+export type Coverage = "complete" | "has_exclusions" | "unaudited";
+
+export interface StampReaderDecision {
+  unit: string;
+  outcome: StampReaderOutcome;
+  alerted: boolean;
+  reason:
+    | "subject_rejected"
+    | "fresh_control_no_subject_rejection"
+    | "missing_control"
+    | "stale_control"
+    | "invalid_control_timestamp"
+    | "missing_control_corpus_hash"
+    | "invalid_control_max_age"
+    | "coverage_unaudited";
+  coverage: Coverage;
+  control_age_ms?: number;
+  guard_skipped: string[];
+}
+
+function parseTimeMs(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function coverageOf(stamp: GuardStamp): { coverage: Coverage; skipped: string[] | null } {
+  if (!Array.isArray(stamp.guard_skipped)) {
+    return { coverage: "unaudited", skipped: null };
+  }
+  return {
+    coverage: stamp.guard_skipped.length === 0 ? "complete" : "has_exclusions",
+    skipped: stamp.guard_skipped,
+  };
+}
+
+function blind(
+  stamp: GuardStamp,
+  reason: Extract<StampReaderDecision["reason"],
+    | "missing_control"
+    | "stale_control"
+    | "invalid_control_timestamp"
+    | "missing_control_corpus_hash"
+    | "invalid_control_max_age"
+    | "coverage_unaudited">,
+  coverage: Coverage,
+  guardSkipped: string[],
+  controlAgeMs?: number,
+): StampReaderDecision {
+  return {
+    unit: stamp.unit,
+    outcome: "BLIND",
+    alerted: true,
+    reason,
+    coverage,
+    control_age_ms: controlAgeMs,
+    guard_skipped: guardSkipped,
+  };
+}
+
+/**
+ * Read a success stamp and decide whether silence is meaningful.
+ *
+ * Interpretation rules:
+ * - missing/stale control => BLIND, not OK;
+ * - missing `guard_skipped` => BLIND because coverage was not audited;
+ * - present `guard_fired_at` with fresh liveness proof => RED;
+ * - recent control + no subject rejection => OK, silent, with exclusions surfaced.
+ */
+export function readGuardStamp(stamp: GuardStamp, now: Date = new Date()): StampReaderDecision {
+  const { coverage, skipped } = coverageOf(stamp);
+  if (skipped === null) {
+    return blind(stamp, "coverage_unaudited", coverage, []);
+  }
+
+  if (!stamp.control_corpus_hash) {
+    return blind(stamp, "missing_control_corpus_hash", coverage, skipped);
+  }
+
+  if (!Number.isFinite(stamp.control_max_age_ms) || stamp.control_max_age_ms <= 0) {
+    return blind(stamp, "invalid_control_max_age", coverage, skipped);
+  }
+
+  const controlAtMs = parseTimeMs(stamp.guard_control_at);
+  if (stamp.guard_control_at && controlAtMs === null) {
+    return blind(stamp, "invalid_control_timestamp", coverage, skipped);
+  }
+  if (controlAtMs === null) {
+    return blind(stamp, "missing_control", coverage, skipped);
+  }
+
+  const controlAgeMs = now.getTime() - controlAtMs;
+  if (controlAgeMs < 0 || controlAgeMs > stamp.control_max_age_ms) {
+    return blind(stamp, "stale_control", coverage, skipped, controlAgeMs);
+  }
+
+  if (stamp.guard_fired_at) {
+    return {
+      unit: stamp.unit,
+      outcome: "RED",
+      alerted: true,
+      reason: "subject_rejected",
+      coverage,
+      control_age_ms: controlAgeMs,
+      guard_skipped: skipped,
+    };
+  }
+
+  return {
+    unit: stamp.unit,
+    outcome: "OK",
+    alerted: false,
+    reason: "fresh_control_no_subject_rejection",
+    coverage,
+    control_age_ms: controlAgeMs,
+    guard_skipped: skipped,
+  };
+}

--- a/src/steg/encoder.ts
+++ b/src/steg/encoder.ts
@@ -172,7 +172,6 @@ export function decodeEmojiSkin(encoded: string): string {
   const codepoints = [...encoded];
   let i = 0;
   while (i < codepoints.length) {
-    const cp = codepoints[i];
     // Check if next is a skin tone modifier
     if (i + 1 < codepoints.length) {
       const mod = codepoints[i + 1];

--- a/test/guard/stamp-reader.test.ts
+++ b/test/guard/stamp-reader.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  readGuardStamp,
+  type GuardStamp,
+  type StampReaderDecision,
+} from "../../src/guard/stamp-reader.js";
+
+const now = new Date("2026-07-31T12:00:00.000Z");
+
+function freshStamp(overrides: Partial<GuardStamp> = {}): GuardStamp {
+  return {
+    unit: "audit.service",
+    stamped_at: "2026-07-31T11:59:00.000Z",
+    guard_control_at: "2026-07-31T11:55:00.000Z",
+    control_corpus_hash: "sha256:known-bad-corpus-v1",
+    control_max_age_ms: 10 * 60 * 1000,
+    guard_skipped: [],
+    ...overrides,
+  };
+}
+
+function unconditionalAlertReader(stamp: GuardStamp): StampReaderDecision {
+  return {
+    unit: stamp.unit,
+    outcome: "RED",
+    alerted: true,
+    reason: "subject_rejected",
+    coverage: "complete",
+    guard_skipped: [],
+  };
+}
+
+describe("success-stamp reader — liveness proof for the guard itself", () => {
+  it("MUST-ALLOW: fresh control plus no subject rejection stays silent", () => {
+    const decision = readGuardStamp(freshStamp(), now);
+
+    expect(decision).toMatchObject({
+      outcome: "OK",
+      alerted: false,
+      reason: "fresh_control_no_subject_rejection",
+      coverage: "complete",
+      control_age_ms: 5 * 60 * 1000,
+      guard_skipped: [],
+    });
+  });
+
+  it("missing control is BLIND, not RED and not OK", () => {
+    const decision = readGuardStamp(freshStamp({ guard_control_at: null }), now);
+
+    expect(decision.outcome).toBe("BLIND");
+    expect(decision.alerted).toBe(true);
+    expect(decision.reason).toBe("missing_control");
+  });
+
+  it("stale control is BLIND, using the explicit max-age field", () => {
+    const decision = readGuardStamp(
+      freshStamp({
+        guard_control_at: "2026-07-31T11:00:00.000Z",
+        control_max_age_ms: 10 * 60 * 1000,
+      }),
+      now,
+    );
+
+    expect(decision.outcome).toBe("BLIND");
+    expect(decision.reason).toBe("stale_control");
+    expect(decision.control_age_ms).toBe(60 * 60 * 1000);
+  });
+
+  it("invalid control timestamp is BLIND rather than silently accepted", () => {
+    const decision = readGuardStamp(freshStamp({ guard_control_at: "not-a-date" }), now);
+
+    expect(decision.outcome).toBe("BLIND");
+    expect(decision.reason).toBe("invalid_control_timestamp");
+  });
+
+  it("missing control corpus hash is BLIND because a shrinking corpus can fake freshness", () => {
+    const decision = readGuardStamp(freshStamp({ control_corpus_hash: null }), now);
+
+    expect(decision.outcome).toBe("BLIND");
+    expect(decision.reason).toBe("missing_control_corpus_hash");
+  });
+
+  it("invalid freshness policy is BLIND because the timestamp has no contract", () => {
+    const decision = readGuardStamp(freshStamp({ control_max_age_ms: 0 }), now);
+
+    expect(decision.outcome).toBe("BLIND");
+    expect(decision.reason).toBe("invalid_control_max_age");
+  });
+
+  it("missing guard_skipped is BLIND because coverage was not audited", () => {
+    const stamp = freshStamp();
+    delete stamp.guard_skipped;
+
+    const decision = readGuardStamp(stamp, now);
+
+    expect(decision.outcome).toBe("BLIND");
+    expect(decision.reason).toBe("coverage_unaudited");
+    expect(decision.coverage).toBe("unaudited");
+  });
+
+  it("explicit skipped subjects are surfaced without pretending coverage is complete", () => {
+    const decision = readGuardStamp(
+      freshStamp({ guard_skipped: ["static-method:Audit.skipMe"] }),
+      now,
+    );
+
+    expect(decision.outcome).toBe("OK");
+    expect(decision.alerted).toBe(false);
+    expect(decision.coverage).toBe("has_exclusions");
+    expect(decision.guard_skipped).toEqual(["static-method:Audit.skipMe"]);
+  });
+
+  it("a subject rejection remains RED when the liveness control is fresh", () => {
+    const decision = readGuardStamp(
+      freshStamp({
+        guard_fired_at: {
+          at: "2026-07-31T11:58:00.000Z",
+          input: "known-real-subject-violation",
+        },
+      }),
+      now,
+    );
+
+    expect(decision.outcome).toBe("RED");
+    expect(decision.alerted).toBe(true);
+    expect(decision.reason).toBe("subject_rejected");
+  });
+
+  it("NEGATIVE CONTROL: an unconditional alert reader fails the must-allow shape", () => {
+    const stamp = freshStamp();
+    const correct = readGuardStamp(stamp, now);
+    const broken = unconditionalAlertReader(stamp);
+
+    expect(correct.alerted).toBe(false);
+    expect(correct.outcome).toBe("OK");
+
+    expect(broken.alerted).toBe(true);
+    expect(broken.outcome).toBe("RED");
+    expect(broken.alerted).not.toBe(correct.alerted);
+  });
+});


### PR DESCRIPTION
Closes #15.

## What changed

- Adds `src/guard/stamp-reader.ts`, a compact readable stamp schema and reader for guard liveness.
- Adds `test/guard/stamp-reader.test.ts` with 10 tests for:
  - fresh control + no subject rejection => `OK`, silent;
  - missing/stale/invalid control => `BLIND`, alert;
  - missing `control_corpus_hash` => `BLIND`;
  - missing `guard_skipped[]` => `BLIND` / coverage unaudited;
  - explicit skipped subjects surfaced as audited exclusions;
  - subject rejection => `RED`;
  - negative control: unconditional-alert reader fails the must-allow shape.
- Restores the existing lint command by adding the missing `typescript-eslint` dev dependency and removing a stale unused variable in `src/steg/encoder.ts`.

## Verification

- `npm ci`
- `npm test -- test/guard/stamp-reader.test.ts` — 10/10 passed
- `npm test -- test/guard/liveness.test.ts test/guard/stamp-reader.test.ts` — 26/26 passed
- `npm run build` — passed
- `npm test` — 40/40 passed
- `npm run lint` — passed

AI disclosure: implemented by Hermes/Codex as maintainer/admin work for ralftpaw/civilian-coordination; decisions and verification are intentional.
