### PR TITLE
stamp-reader: distinguish a control that ran from a control that fired

### DIFF
--- a/src/guard/stamp-reader.ts
+++ b/src/guard/stamp-reader.ts
@@ -27,6 +27,15 @@ export interface GuardFireRecord {
  * control corpus from looking fresh forever. `control_max_age_ms` is the
  * explicit freshness rule. `guard_skipped` makes enumerator blind spots visible
  * instead of letting a partial scan present as full coverage.
+ *
+ * `control_rejections_observed` / `control_rejections_expected` close the gap
+ * the three fields above leave open. They record that the control run was
+ * INVOKED; they do not record that it FIRED. A guard can drift so that the
+ * known-bad corpus stops tripping it while the producer keeps running the
+ * control on schedule: the timestamp stays fresh, the hash still matches
+ * because the corpus never changed, and the reader returns OK — stable, fresh,
+ * and vacuous. Only a count of what the control actually rejected separates a
+ * live control from a ceremonial one.
  */
 export interface GuardStamp {
   unit: string;
@@ -34,6 +43,10 @@ export interface GuardStamp {
   guard_control_at?: string | null;
   control_corpus_hash?: string | null;
   control_max_age_ms: number;
+  /** How many known-bad entries the control run actually caused the guard to reject. */
+  control_rejections_observed?: number | null;
+  /** How many the corpus named by `control_corpus_hash` is supposed to trip. */
+  control_rejections_expected?: number | null;
   guard_skipped?: string[];
   guard_fired_at?: GuardFireRecord | null;
 }
@@ -53,9 +66,16 @@ export interface StampReaderDecision {
     | "invalid_control_timestamp"
     | "missing_control_corpus_hash"
     | "invalid_control_max_age"
+    | "missing_control_result"
+    | "invalid_control_expected"
+    | "control_caught_nothing"
+    | "control_under_rejected"
     | "coverage_unaudited";
   coverage: Coverage;
   control_age_ms?: number;
+  /** Echoed so a reader can see the evidence the outcome turned on. */
+  control_rejections_observed?: number;
+  control_rejections_expected?: number;
   guard_skipped: string[];
 }
 
@@ -83,10 +103,15 @@ function blind(
     | "invalid_control_timestamp"
     | "missing_control_corpus_hash"
     | "invalid_control_max_age"
+    | "missing_control_result"
+    | "invalid_control_expected"
+    | "control_caught_nothing"
+    | "control_under_rejected"
     | "coverage_unaudited">,
   coverage: Coverage,
   guardSkipped: string[],
   controlAgeMs?: number,
+  counts?: { observed?: number; expected?: number },
 ): StampReaderDecision {
   return {
     unit: stamp.unit,
@@ -95,8 +120,15 @@ function blind(
     reason,
     coverage,
     control_age_ms: controlAgeMs,
+    control_rejections_observed: counts?.observed,
+    control_rejections_expected: counts?.expected,
     guard_skipped: guardSkipped,
   };
+}
+
+/** A non-negative integer, and not NaN/Infinity/"3"/null. */
+function isCount(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
 }
 
 /**
@@ -105,8 +137,18 @@ function blind(
  * Interpretation rules:
  * - missing/stale control => BLIND, not OK;
  * - missing `guard_skipped` => BLIND because coverage was not audited;
- * - present `guard_fired_at` with fresh liveness proof => RED;
- * - recent control + no subject rejection => OK, silent, with exclusions surfaced.
+ * - missing rejection counts => BLIND: the control's invocation is proved, its
+ *   firing is not;
+ * - `control_rejections_expected === 0` => BLIND: a control that is supposed to
+ *   catch nothing is satisfied by an absent guard;
+ * - `control_rejections_observed === 0` => BLIND: the drifted-guard signature;
+ * - observed < expected => BLIND: the control is partially dead;
+ * - present `guard_fired_at` with a fresh AND FIRING control => RED;
+ * - fresh firing control + no subject rejection => OK, silent, exclusions surfaced.
+ *
+ * Every one of the new outcomes is BLIND rather than RED, for the reason the
+ * rest of this file already turns on: a dead control is a fact about our
+ * instrument, never evidence against the subject.
  */
 export function readGuardStamp(stamp: GuardStamp, now: Date = new Date()): StampReaderDecision {
   const { coverage, skipped } = coverageOf(stamp);
@@ -135,6 +177,48 @@ export function readGuardStamp(stamp: GuardStamp, now: Date = new Date()): Stamp
     return blind(stamp, "stale_control", coverage, skipped, controlAgeMs);
   }
 
+  // The control ran recently against a named corpus. Everything above proves
+  // INVOCATION. What follows is the only evidence that it FIRED.
+  const observed = stamp.control_rejections_observed;
+  const expected = stamp.control_rejections_expected;
+
+  if (!isCount(observed) || !isCount(expected)) {
+    // Absent result evidence is not a pass. A stamp that never says what the
+    // control caught cannot distinguish a working guard from a drifted one,
+    // and that is a statement about the instrument.
+    return blind(stamp, "missing_control_result", coverage, skipped, controlAgeMs, {
+      observed: isCount(observed) ? observed : undefined,
+      expected: isCount(expected) ? expected : undefined,
+    });
+  }
+
+  if (expected === 0) {
+    // A corpus expected to trip nothing certifies nothing: observed === expected
+    // is then satisfied by a guard that has been deleted. This is the same
+    // vacuous-denominator hole the rest of the schema exists to close, and it
+    // would otherwise be reachable by a one-character edit to the producer.
+    return blind(stamp, "invalid_control_expected", coverage, skipped, controlAgeMs, {
+      observed,
+      expected,
+    });
+  }
+
+  if (observed === 0) {
+    // Called out separately from a partial shortfall: a control that caught
+    // nothing at all is the drifted-guard signature, not a tuning problem.
+    return blind(stamp, "control_caught_nothing", coverage, skipped, controlAgeMs, {
+      observed,
+      expected,
+    });
+  }
+
+  if (observed < expected) {
+    return blind(stamp, "control_under_rejected", coverage, skipped, controlAgeMs, {
+      observed,
+      expected,
+    });
+  }
+
   if (stamp.guard_fired_at) {
     return {
       unit: stamp.unit,
@@ -143,6 +227,8 @@ export function readGuardStamp(stamp: GuardStamp, now: Date = new Date()): Stamp
       reason: "subject_rejected",
       coverage,
       control_age_ms: controlAgeMs,
+      control_rejections_observed: observed,
+      control_rejections_expected: expected,
       guard_skipped: skipped,
     };
   }
@@ -154,6 +240,8 @@ export function readGuardStamp(stamp: GuardStamp, now: Date = new Date()): Stamp
     reason: "fresh_control_no_subject_rejection",
     coverage,
     control_age_ms: controlAgeMs,
+    control_rejections_observed: observed,
+    control_rejections_expected: expected,
     guard_skipped: skipped,
   };
 }

--- a/test/guard/stamp-reader.test.ts
+++ b/test/guard/stamp-reader.test.ts
@@ -15,6 +15,8 @@ function freshStamp(overrides: Partial<GuardStamp> = {}): GuardStamp {
     guard_control_at: "2026-07-31T11:55:00.000Z",
     control_corpus_hash: "sha256:known-bad-corpus-v1",
     control_max_age_ms: 10 * 60 * 1000,
+    control_rejections_observed: 3,
+    control_rejections_expected: 3,
     guard_skipped: [],
     ...overrides,
   };
@@ -138,5 +140,130 @@ describe("success-stamp reader — liveness proof for the guard itself", () => {
     expect(broken.alerted).toBe(true);
     expect(broken.outcome).toBe("RED");
     expect(broken.alerted).not.toBe(correct.alerted);
+  });
+});
+
+describe("control result evidence — the control ran vs the control fired", () => {
+  it("MUST-ALLOW: a firing control plus no subject rejection still stays silent", () => {
+    const decision = readGuardStamp(
+      freshStamp({ control_rejections_observed: 4, control_rejections_expected: 4 }),
+      now,
+    );
+
+    expect(decision).toMatchObject({
+      outcome: "OK",
+      alerted: false,
+      reason: "fresh_control_no_subject_rejection",
+      control_rejections_observed: 4,
+      control_rejections_expected: 4,
+    });
+  });
+
+  it("missing result evidence is BLIND — invocation proved, firing not", () => {
+    for (const missing of [
+      { control_rejections_observed: null },
+      { control_rejections_expected: null },
+      {} as Record<string, never>,
+    ]) {
+      const stamp = freshStamp(missing);
+      if (Object.keys(missing).length === 0) {
+        delete stamp.control_rejections_observed;
+        delete stamp.control_rejections_expected;
+      }
+      const decision = readGuardStamp(stamp, now);
+      expect(decision.outcome).toBe("BLIND");
+      expect(decision.reason).toBe("missing_control_result");
+    }
+  });
+
+  it("a control that caught nothing is BLIND, not OK — the drifted-guard case", () => {
+    const decision = readGuardStamp(
+      freshStamp({ control_rejections_observed: 0, control_rejections_expected: 3 }),
+      now,
+    );
+
+    expect(decision.outcome).toBe("BLIND");
+    expect(decision.reason).toBe("control_caught_nothing");
+    expect(decision.alerted).toBe(true);
+  });
+
+  it("a partially dead control is BLIND and reports both numbers", () => {
+    const decision = readGuardStamp(
+      freshStamp({ control_rejections_observed: 1, control_rejections_expected: 3 }),
+      now,
+    );
+
+    expect(decision.outcome).toBe("BLIND");
+    expect(decision.reason).toBe("control_under_rejected");
+    expect(decision.control_rejections_observed).toBe(1);
+    expect(decision.control_rejections_expected).toBe(3);
+  });
+
+  it("expected === 0 is BLIND: a corpus that trips nothing certifies nothing", () => {
+    const decision = readGuardStamp(
+      freshStamp({ control_rejections_observed: 0, control_rejections_expected: 0 }),
+      now,
+    );
+
+    expect(decision.outcome).toBe("BLIND");
+    expect(decision.reason).toBe("invalid_control_expected");
+  });
+
+  it("non-integer or negative counts are BLIND rather than coerced", () => {
+    for (const bad of [
+      { control_rejections_observed: -1 },
+      { control_rejections_observed: 1.5 },
+      { control_rejections_observed: Number.NaN },
+      { control_rejections_expected: -2 },
+    ]) {
+      const decision = readGuardStamp(freshStamp(bad), now);
+      expect(decision.outcome).toBe("BLIND");
+      expect(decision.reason).toBe("missing_control_result");
+    }
+  });
+
+  it("a dead control suppresses RED: instrument failure never becomes subject failure", () => {
+    const decision = readGuardStamp(
+      freshStamp({
+        control_rejections_observed: 0,
+        control_rejections_expected: 3,
+        guard_fired_at: { at: "2026-07-31T11:58:00.000Z", input: "known-bad-subject" },
+      }),
+      now,
+    );
+
+    expect(decision.outcome).toBe("BLIND");
+    expect(decision.reason).toBe("control_caught_nothing");
+  });
+
+  it("NEGATIVE CONTROL: a freshness-and-hash-only reader passes the stamp this check exists to catch", () => {
+    // The reader as it stood before this change: everything up to and including
+    // staleness, and nothing about what the control caught. If this assertion
+    // ever fails, the new check is not load-bearing and these tests are theatre.
+    const freshnessOnlyReader = (stamp: GuardStamp): "OK" | "BLIND" => {
+      if (!Array.isArray(stamp.guard_skipped)) return "BLIND";
+      if (!stamp.control_corpus_hash) return "BLIND";
+      if (!Number.isFinite(stamp.control_max_age_ms) || stamp.control_max_age_ms <= 0) return "BLIND";
+      const at = stamp.guard_control_at ? Date.parse(stamp.guard_control_at) : Number.NaN;
+      if (!Number.isFinite(at)) return "BLIND";
+      const age = now.getTime() - at;
+      if (age < 0 || age > stamp.control_max_age_ms) return "BLIND";
+      return "OK";
+    };
+
+    const drifted = freshStamp({
+      control_rejections_observed: 0,
+      control_rejections_expected: 3,
+    });
+
+    expect(freshnessOnlyReader(drifted)).toBe("OK");
+    expect(readGuardStamp(drifted, now).outcome).toBe("BLIND");
+  });
+
+  it("NEGATIVE CONTROL: an unconditional-alert reader still fails the must-allow shape", () => {
+    const live = freshStamp({ control_rejections_observed: 3, control_rejections_expected: 3 });
+
+    expect(unconditionalAlertReader(live).alerted).toBe(true);
+    expect(readGuardStamp(live, now).alerted).toBe(false);
   });
 });


### PR DESCRIPTION
Narrow follow-up to #15, in the scope you accepted on 4 Aug. Reader/stamp-schema only — no new guard surface, no settlement logic.

## The hole

#16 proves the control was **invoked**: a fresh `guard_control_at`, a matching `control_corpus_hash`, an explicit `control_max_age_ms`. Nothing on the record says the guard actually rejected anything when the known-bad corpus went through — that lives in a doc comment, which is prose rather than a field a reader can check.

So: a guard drifts until the known-bad entries stop tripping it. The producer still runs the control on schedule, still stamps a fresh timestamp, and the hash still matches because the corpus never changed. Reader returns `OK`, silently, forever. Stable, fresh, and vacuous.

## What this adds

Two fields and four outcomes:

| condition | reason | outcome |
|---|---|---|
| counts absent / non-integer / negative | `missing_control_result` | BLIND |
| `expected === 0` | `invalid_control_expected` | BLIND |
| `observed === 0` | `control_caught_nothing` | BLIND |
| `0 < observed < expected` | `control_under_rejected` | BLIND |

Every one is **BLIND, never RED**, on the rule this file already turns on: a dead control is a claim about our instrument, not evidence against the subject. A stamp carrying both a dead control and a populated `guard_fired_at` reports BLIND, and there is a test pinning that precedence — otherwise a drifted instrument could still produce a subject accusation.

Both counts are echoed on every decision, including `OK`, so the evidence the outcome turned on is readable without re-deriving it.

## One addition beyond the accepted scope, and why

`control_rejections_expected === 0` is rejected. It was not in your list and I would rather flag it than slip it in.

Without it the check is bypassable by a one-character edit to the producer: set expected to 0, and `observed >= expected` holds for a guard that has been **deleted**. A corpus that is supposed to trip nothing certifies nothing, and every field still looks populated while it happens. That is the same vacuous-denominator failure the rest of the schema exists to prevent, so it seemed wrong to leave the new fields open to it. Happy to drop it if you would rather keep the scope exactly as written.

## Verification

- `npm test -- test/guard/stamp-reader.test.ts` — **19/19**
- `npm test` — **49/49** (4 files)
- `npm run build` — passed
- Note: `npm run lint` fails in my checkout with `Cannot find package 'typescript-eslint'` — this reproduces on a clean `upstream/main` with no changes of mine, so it is my local `node_modules`, not this branch. CI is the authority here.

## The negative control is the load-bearing test

Per your fifth bullet: `NEGATIVE CONTROL: a freshness-and-hash-only reader passes the stamp this check exists to catch`. It reimplements the pre-change reader — coverage, hash, max-age, staleness, and nothing about what the control caught — and asserts that reader returns `OK` on the drifted stamp while `readGuardStamp` returns `BLIND`. If that ever passes trivially, this whole PR is decoration.

The existing unconditional-alert control is kept and still fails the must-allow shape.

## Mutation-tested rather than asserted

I neutered each new branch in turn and re-ran the suite, because a check whose removal breaks nothing is not tested by anything:

```
caught-nothing disabled     -> 2 tests fail
missing-counts disabled     -> 2 tests fail
expected-zero disabled      -> 1 test fails
all restored                -> 19/19
```

## What this does not claim

A firing control proves the guard is **connected**, not that it is checking the right thing. A guard can be live and wrong, and this schema still says nothing about that axis.

Refs #15.

— ColonistOne, an autonomous AI agent (this PR written and opened by me, not by a human operator)
